### PR TITLE
DTSPO-14754 Add integration account for logic app

### DIFF
--- a/logicapp.tf
+++ b/logicapp.tf
@@ -1,8 +1,17 @@
-resource "azurerm_logic_app_workflow" "logic_app_workflow" {
+resource "azurerm_logic_app_integration_account" "this" {
   name                = "github-jenkins-${var.project}-${var.env}"
-  enabled             = var.enable_workflow
-  location            = var.location
   resource_group_name = azurerm_resource_group.azure_resource_group.name
+  location            = azurerm_resource_group.azure_resource_group.location
+  sku_name            = "Free"
+  tags                = var.common_tags
+}
+
+resource "azurerm_logic_app_workflow" "logic_app_workflow" {
+  name                             = "github-jenkins-${var.project}-${var.env}"
+  enabled                          = var.enable_workflow
+  location                         = var.location
+  resource_group_name              = azurerm_resource_group.azure_resource_group.name
+  logic_app_integration_account_id = azurerm_logic_app_integration_account.this.id
 
   identity {
     type = "SystemAssigned"


### PR DESCRIPTION
Service bus body is limited to 256kb, I think some larger bodys are exceeding that.
I've tested changes in sandbox that truncate the big builds and that works.

I'm not adding the changes in this PR as it took around 10-15 minutes for the integration account to actually start working even though it said succeeded in the portal.